### PR TITLE
Fix bug with required options when --help flag is present

### DIFF
--- a/examples/show-examples.js
+++ b/examples/show-examples.js
@@ -12,4 +12,17 @@ cli.command('hoo', {
   examples: ['this is an example', 'yet another']
 })
 
+cli.command('send', {
+  desc: 'Send a message',
+  examples: ['-t "hi there" -w user@example.com']
+}).option('text', {
+  alias: 't',
+  desc: 'Message body',
+  required: true // <-- Works with required flag!
+}).option('who', {
+  alias: 'w',
+  desc: 'Recipient email address',
+  required: true // <-- Works with required flag!
+})
+
 cli.parse()

--- a/src/plugins/required-option.ts
+++ b/src/plugins/required-option.ts
@@ -4,6 +4,9 @@ export default () => (cli: Cac) => {
   cli.on('parsed', (command, _, flags) => {
     if (!command) return
 
+    // The presence of help trumps required option processing
+    if (flags.help) return
+
     const missingRequiredOptions = command.options.options.filter(option => {
       const isRequired = option.required
       const isMissing = typeof flags[option.name] === 'undefined'


### PR DESCRIPTION
Currently if you have a command with any options marked `required: true`, running `node cli.js <command> --help` will fail stating those options are missing, rather than showing the registered examples.

Example:

`cac: 5.0.15`

```typescript
import cac from "cac";

const cli = cac({
  bin: "messenger"
});

cli
  .command(
    "send",
    {
      desc: "Send a message",
      examples: ['-t "oh hi" -w user@example.com']
    },
    (input, flags) => {
      console.log("Message sent");
    }
  )
  .option("text", {
    alias: "t",
    desc: "Message you want to send",
    required: true
  })
  .option("who", {
    alias: "w",
    desc: "To who? Email address.",
    required: true
  });

cli.parse();
```

Not sure if this was intended behavior, but it might be ideal to check for the lack of options associated with a command when `--help` is present, or let `--help` trump the fact that any flags are present.