### PR TITLE
Update README docs to accurately reflect version logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cli.command('lint [...files]', 'Lint files').action((files, options) => {
 
 // Display help message when `-h` or `--help` appears
 cli.help()
-// Display version number when `-h` or `--help` appears
+// Display version number when `-h`, `--help`, `-v`, or `--version` appears
 cli.version('0.0.0')
 
 cli.parse()

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ cli.command('lint [...files]', 'Lint files').action((files, options) => {
 
 // Display help message when `-h` or `--help` appears
 cli.help()
-// Display version number when `-h`, `--help`, `-v`, or `--version` appears
+// Display version number when `-v` or `--version` appears
+// It's also used in help message
 cli.version('0.0.0')
 
 cli.parse()


### PR DESCRIPTION
Just noticed this when browsing through: the version will be logged for all `help` and `version` option variants, not only `-h`/`--help`.