### PR TITLE
changed events module to named export.

### DIFF
--- a/src/CAC.ts
+++ b/src/CAC.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events'
+import { EventEmitter } from 'events'
 import mri from 'mri'
 import Command, {
   GlobalCommand,


### PR DESCRIPTION
This is a fix for error like:

```
../node_modules/cac/types/CAC.d.ts:2:8 - error TS1192: Module '"events"' has no default export.                                  

2 import EventEmitter from 'events';
         ~~~~~~~~~~~~
```

this may be regression on ver 6.5.1
https://github.com/cacjs/cac/commit/70bc5331842598cb793d496fccc7a43ac017b246#diff-8a596384c8f493a602203435e2130014L1

And it's same workaround as before:
https://github.com/cacjs/cac/commit/c087963e8a89c23f6dcde0a430dcd07d4a900666
