### PR TITLE
Replace Deno.platform usages

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -10,5 +10,5 @@ export const exit = (code: number) => {
 export const processArgs = deno ? ['deno'].concat(Deno.args) : process.argv
 
 export const platformInfo = deno
-  ? `${Deno.platform.os}-${Deno.platform.arch} deno-${Deno.version.deno}`
+  ? `${Deno.build.os}-${Deno.build.arch} deno-${Deno.version.deno}`
   : `${process.platform}-${process.arch} node-${process.version}`


### PR DESCRIPTION
`Deno.platform` was deprecated and it was reorganized into Deno.build at denoland/deno#1879 . This PR replaces `Deno.platform` usages with `Deno.build`.