### PR TITLE
docs: add a title for Negated Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   - [Command-specific Options](#command-specific-options)
   - [Dash in option names](#dash-in-option-names)
   - [Brackets](#brackets)
+  - [Negated Options](#negated-options)
   - [Variadic Arguments](#variadic-arguments)
   - [Dot-nested Options](#dot-nested-options)
   - [Default Command](#default-command)
@@ -171,6 +172,8 @@ cli
 
 cli.parse()
 ```
+
+### Negated Options
 
 To allow an option whose value is `false`, you need to manually specify a negated option:
 


### PR DESCRIPTION
It takes me a while to realize that `--no-config` will set the value of `config` to true.

So I think maybe `Negated Options` can have its own title in the usage