### PR TITLE
fix: stop running command with help or version flag

### DIFF
--- a/src/CAC.ts
+++ b/src/CAC.ts
@@ -208,10 +208,12 @@ class CAC extends EventEmitter {
 
     if (this.options.help && this.showHelpOnExit) {
       this.outputHelp()
+      run = false
     }
 
     if (this.options.version && this.showVersionOnExit) {
       this.outputVersion()
+      run = false
     }
 
     const parsedArgv = { args: this.args, options: this.options }


### PR DESCRIPTION
```shell
# cac/example
node help.js lint --help

help.js v0.0.0

Usage:
  $ help.js lint [...files]

Options:
  --type [type]  Choose a project type (default: node)
  --name <name>  Provide your name
  -h, --help     Display this message
  -v, --version  Display version number
[] { '--': [], type: 'node', h: true, help: true } <<-- command is still running
```

BTW, the `showVersionOnExit` and `showHelpOnExit` may also be outdated? Since they do not actually Exit anymore.