### PR TITLE
docs: add usage api

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@
     - [cli.version(version, customFlags?)](#cliversionversion-customflags)
     - [cli.help(callback?)](#clihelpcallback)
     - [cli.outputHelp()](#clioutputhelp)
+    - [cli.usage(text)](#cliusagetext)
   - [Command Instance](#command-instance)
     - [command.option()](#commandoption)
     - [command.action(callback)](#commandactioncallback)
     - [command.alias(name)](#commandaliasname)
     - [command.allowUnknownOptions()](#commandallowunknownoptions)
     - [command.example(example)](#commandexampleexample)
+    - [command.usage(text)](#commandusagetext)
   - [Events](#events)
 - [FAQ](#faq)
   - [How is the name written and pronounced?](#how-is-the-name-written-and-pronounced)
@@ -74,7 +76,7 @@ Use CAC as simple argument parser:
 const cli = require('cac')()
 
 cli.option('--type <type>', 'Choose a project type', {
-  default: 'node',
+  default: 'node'
 })
 
 const parsed = cli.parse()
@@ -91,7 +93,7 @@ console.log(JSON.stringify(parsed, null, 2))
 const cli = require('cac')()
 
 cli.option('--type [type]', 'Choose a project type', {
-  default: 'node',
+  default: 'node'
 })
 cli.option('--name <name>', 'Provide your name')
 
@@ -141,7 +143,7 @@ Options in kebab-case should be referenced in camelCase in your code:
 cli
   .command('dev', 'Start dev server')
   .option('--clear-screen', 'Clear screen')
-  .action((options) => {
+  .action(options => {
     console.log(options.clearScreen)
   })
 ```
@@ -221,7 +223,7 @@ cli
   .command('build', 'desc')
   .option('--env <env>', 'Set envs')
   .example('--env.API_SECRET xxx')
-  .action((options) => {
+  .action(options => {
     console.log(options)
   })
 

--- a/README.md
+++ b/README.md
@@ -408,6 +408,12 @@ interface HelpSection {
 
 Output help message. Optional `subCommand` argument if you want to output the help message for the matched sub-command instead of the global help message.
 
+#### cli.usage(text)
+
+- Type: `(text: string) => CLI`
+
+Add a global usage text. This is not used by sub-commands.
+
 ### Command Instance
 
 Command instance is created by invoking the `cli.command` method:
@@ -461,6 +467,12 @@ Add an example which will be displayed at the end of help message.
 ```ts
 type CommandExample = ((name: string) => string) | string
 ```
+
+#### command.usage(text)
+
+- Type: `(text: string) => Command`
+
+Add a usage text for this command.
 
 ### Events
 


### PR DESCRIPTION
It seems there aren't references to `cli.usage(text)` and `command.usage(text)`.
I think they exist in README.md is more useful, so I added.

https://github.com/cacjs/cac/blob/d2c6b8a169359d0a5f17f0e3aa30e9c0e0a920ad/src/CAC.ts#L60-L68

https://github.com/cacjs/cac/blob/d2c6b8a169359d0a5f17f0e3aa30e9c0e0a920ad/src/Command.ts#L58-L61