### PR TITLE
fix: make version format consistent

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -140,7 +140,7 @@ class Command {
 
     let sections: HelpSection[] = [
       {
-        body: `${name}${versionNumber ? ` v${versionNumber}` : ''}`
+        body: `${name}${versionNumber ? `/${versionNumber}` : ''}`
       }
     ]
 

--- a/src/__test__/__snapshots__/index.test.ts.snap
+++ b/src/__test__/__snapshots__/index.test.ts.snap
@@ -15,7 +15,7 @@ exports[`basic-usage: basic-usage 1`] = `
 `;
 
 exports[`help: help 1`] = `
-"help.js v0.0.0
+"help.js/0.0.0
 
 Usage:
   $ help.js <command> [options]


### PR DESCRIPTION
We are trying to display version of multiple packages:

```ts
const program = cac('vuepress')

const versionCli = require('../package.json').version
const versionCore = require('@vuepress/core/package.json').version
program.version(`core@${versionCore} vuepress/cli@${versionCli}`)
```

However, the version format is different in `--help` and `--version` command:

```bash
$ vuepress --version
vuepress/core@2.0.0-alpha.3 vuepress/cli@2.0.0-alpha.3 linux-x64 node-v12.16.1

$ vuepress --help
vuepress vcore@2.0.0-alpha.3 vuepress/cli@2.0.0-alpha.3
```