### PR TITLE
fix: tweak `setDotProp` in utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,9 +110,9 @@ export const setDotProp = (
         ? val
         : x != null
         ? x
-        : !!~keys[i + 1].indexOf('.') || !(+keys[i + 1] > -1)
-        ? {}
-        : []
+        : +keys[i + 1] > -1
+        ? []
+        : {}
   }
 }
 


### PR DESCRIPTION
I see the `setDotProp` use in [CAC.js](https://github.com/cacjs/cac/blob/master/src/CAC.ts#L309)

It before use `split('.')`. So I think doesn't need `keys[i + 1].indexOf('.')` condition.