### PR TITLE
Feature/better help output for negated options

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,17 @@ cli
 ```
 
 This will let CAC set the default value of `config` to true, and you can use `--no-config` flag to set it to `false`.
+This also results in the familiar `[no-]foo` syntax in `cli.help()` output:
+
+```
+Usage:
+  $ foo build [project]
+
+Options:
+  --[no-]config <path>   Disable config file/Use a custom config file
+  -h, --help             Display this message
+  -v, --version          Display version number
+```
 
 ### Variadic Arguments
 

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -103,6 +103,34 @@ test('negated option validation', () => {
   expect(options.config).toBe(false)
 })
 
+test('negated option help output', () => {
+  const cli = cac()
+
+  cli.option('--config <config>', 'Use custom config file')
+  cli.option('--no-config', 'Skip')
+
+  const saved = console.log
+  let output = ''
+  try {
+    console.log = (msg, more) => {
+      if (more) throw new Error('Unexpected multi-arg call to console.log')
+      output += msg
+    }
+    cli.outputHelp()
+    expect(output).toBe(
+      `
+
+Usage:
+  $  <command> [options]
+
+Options:
+  --[no-]config <config>   Skip/Use custom config file `
+    )
+  } finally {
+    console.log = saved
+  }
+})
+
 test('array types without transformFunction', () => {
   const cli = cac()
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,9 +79,7 @@ export const getMriOptions = (options: Option[]) => {
 }
 
 export const findLongest = (arr: string[]) => {
-  return arr.sort((a, b) => {
-    return a.length > b.length ? -1 : 1
-  })[0]
+  return arr.reduce((acc, a) => (a.length > acc.length ? a : acc))
 }
 
 export const padRight = (str: string, length: number) => {


### PR DESCRIPTION
Two commits here.  The first is completely orthogonal to this, you can skip it, but I couldn't resist.

The second one implements the idea briefly discussed.   I added a test.  See the commit messages for details.

By the way, you have some very intrusive git hooks setup.  Whenever I do a commit, it takes 7 seconds to run the tests.  Plus, something in the hooks runs a some kind of process behind the scenes that substantially reformat the whole file, changing my commit, including parts of the file I didn't even touch. I do not want to author those formatting changes (at least not as a part of this PR).  It's totally fine to want a certain formatting, but IMO it's a bad idea to attribute those to people wanting to add specific features or fix specific bugs.  Just my opinion.

Even doing a rebase to get rid of them was complicated, I had to completely wipe out `.git/hooks` to be able to function properly.

Other than that, fantastic nifty little project you have here, congratulations!