### PR TITLE
fix: default exports.require should be pointed to index-compat.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./index-compat.js"
     },
     "./package.json": "./package.json",
     "./": "./"


### PR DESCRIPTION
In latest version the default commonjs export was changed to `./dist/index.js` via this config:

```json
  "exports": {
    ".": {
      "import": "./dist/index.mjs",
      "require": "./dist/index.js"
    },
    "./package.json": "./package.json",
    "./": "./"
  },
```

This breaks use case like

```js
require('cac')()
```