### PR TITLE
fix: make cac work on Deno 1.16

### DIFF
--- a/scripts/build-deno.ts
+++ b/scripts/build-deno.ts
@@ -18,7 +18,7 @@ function node2deno(options: { types: typeof Types }): PluginObj {
           }
           source.value += '.ts'
         } else if (source.value === 'events') {
-          source.value = `https://deno.land/std@0.80.0/node/events.ts`
+          source.value = `https://deno.land/std@0.114.0/node/events.ts`
         } else if (source.value === 'mri') {
           source.value = `https://cdn.skypack.dev/mri`
         }


### PR DESCRIPTION
See https://deno.com/blog/v1.16#improvements-to-web-streams-api

> `ReadableStream.getIterator` has been removed. This method has been deprecated since Deno 1.7, and was never implemented in any browser. The `ReadableStream` itself has always implemented the `AsyncIterable` protocol, so use that instead when iterating over a stream.