### PR TITLE
fix(docs): sao documentation url ⚔️

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ CAC is very similar to Commander.js, while the latter does not support dot neste
 
 _And maybe more..._
 
-Basically I made CAC to fulfill my own needs for building CLI apps like [Poi](https://poi.js.org), [SAO](https://saojs.org) and all my CLI apps. It's small, simple but powerful :P
+Basically I made CAC to fulfill my own needs for building CLI apps like [Poi](https://poi.js.org), [SAO](https://sao.vercel.app) and all my CLI apps. It's small, simple but powerful :P
 
 ## Project Stats
 


### PR DESCRIPTION
For future suggestion, you may use redirect url that dynamically return to official documentation without editing the url in readme, e.g using some redirect link platforms like bitly.