### PR TITLE
feat: throw error on unused args

### DIFF
--- a/src/CAC.ts
+++ b/src/CAC.ts
@@ -220,7 +220,11 @@ class CAC extends EventEmitter {
       this.unsetMatchedCommand()
     }
 
-    if (this.options.version && this.showVersionOnExit && this.matchedCommandName == null) {
+    if (
+      this.options.version &&
+      this.showVersionOnExit &&
+      this.matchedCommandName == null
+    ) {
       this.outputVersion()
       run = false
       this.unsetMatchedCommand()
@@ -327,6 +331,8 @@ class CAC extends EventEmitter {
     command.checkOptionValue()
 
     command.checkRequiredArgs()
+
+    command.checkUnusedArgs()
 
     const actionArgs: any[] = []
     command.args.forEach((arg, index) => {

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -295,6 +295,22 @@ class Command {
       }
     }
   }
+
+  /**
+   * Check if the number of args is more than expected
+   */
+  checkUnusedArgs() {
+    const hasVariadicArg = this.args.some((arg) => arg.variadic)
+    const maximumArgsCount = hasVariadicArg ? Infinity : this.args.length
+
+    if (maximumArgsCount < this.cli.args.length) {
+      const argsString = this.cli.args
+        .slice(maximumArgsCount)
+        .map((arg) => `\`${arg}\``)
+        .join(', ')
+      throw new CACError(`Unused args: ${argsString}`)
+    }
+  }
 }
 
 class GlobalCommand extends Command {

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -165,6 +165,16 @@ test('throw on unknown options', () => {
   }).toThrowError('Unknown option `--xx`')
 })
 
+test('throw on unused args', () => {
+  const cli = cac()
+
+  cli.command('build [entry]', 'Build your app').action(() => {})
+
+  expect(() => {
+    cli.parse(`node bin build app.js foo bar`.split(' '))
+  }).toThrowError('Unused args: `foo`, `bar`')
+})
+
 describe('--version in help message', () => {
   test('sub command', async () => {
     const output = await getOutput('help.js', ['lint', '--help'])


### PR DESCRIPTION
When the number of args passed is more than expected, it is likely to be mistaken the command syntax.
I think it would be good to have an error in this situation.

If I should implement something like `allowUnknownOptions`, I would do it.
