### PR TITLE
fix: compat with NodeNext moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./index-compat.js"
     },


### PR DESCRIPTION
Without this line, it will throw an error when setting `"moduleResolution": "NodeNext"` in tsconfig:

```bash
error TS7016: Could not find a declaration file for module 'cac'
```