### PR TITLE
Added aliases on outputHelp

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -156,6 +156,9 @@ class Command {
       const longestCommandName = findLongest(
         commands.map((command) => command.rawName)
       )
+      const longestCommandDescription = findLongest(
+        commands.map((command) => command.description)
+      )
       sections.push({
         title: 'Commands',
         body: commands
@@ -163,7 +166,14 @@ class Command {
             return `  ${padRight(
               command.rawName,
               longestCommandName.length
-            )}  ${command.description}`
+            )}  ${padRight(
+              command.description,
+              longestCommandDescription.length
+            )}  ${
+              command.aliasNames.length
+                ? `@ ${command.aliasNames.join(', ')}`
+                : ''
+            }`
           })
           .join('\n'),
       })


### PR DESCRIPTION
Found myself having to look in the code to check if there was any easier way to execute the command. It turned out lots of them had aliases.

<img width="745" alt="Screen Shot 2022-10-16 at 3 21 30 PM" src="https://user-images.githubusercontent.com/1843792/196051599-34dc8eaf-3559-4f20-a422-c653d319a229.png">
