### PR TITLE
Fix #151 (inverted default commands)

### DIFF
--- a/examples/default-command-inverted.js
+++ b/examples/default-command-inverted.js
@@ -1,0 +1,11 @@
+require('ts-node/register')
+const cli = require('../src/index').cac()
+
+const command = cli
+  .command("something", "Do something")
+  .alias("!")
+  .action(async () => {
+    console.log("Did something!");
+  });
+
+cli.parse()

--- a/examples/default-command.js
+++ b/examples/default-command.js
@@ -1,0 +1,11 @@
+require('ts-node/register')
+const cli = require('../src/index').cac()
+
+const command = cli
+  .command("", "Do something")
+  .alias("something")
+  .action(async () => {
+    console.log("Did something!");
+  });
+
+cli.parse()

--- a/src/CAC.ts
+++ b/src/CAC.ts
@@ -200,7 +200,7 @@ class CAC extends EventEmitter {
     if (shouldParse) {
       // Search the default command
       for (const command of this.commands) {
-        if (command.name === '') {
+        if (command.isDefaultCommand) {
           shouldParse = false
           const parsed = this.mri(argv.slice(2), command)
           this.setParsedInfo(parsed, command)

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -176,3 +176,26 @@ describe('--version in help message', () => {
     expect(output).toContain(`--version`)
   })
 })
+
+describe("default commands", () => {
+  test("simple: empty call", async () => {
+    const output = await getOutput('default-command.js', [])
+    expect(output).toContain("Did something!")
+  })
+
+  test("simple: name alias call", async () => {
+    const output = await getOutput('default-command.js', ["something"])
+    expect(output).toContain("Did something!")
+  })
+
+  // See https://github.com/cacjs/cac/issues/151
+  test("inverted: empty call", async () => {
+    const output = await getOutput('default-command-inverted.js', [])
+    expect(output).toContain("Did something!")
+  })
+  
+  test("inverted: name alias call", async () => {
+    const output = await getOutput('default-command-inverted.js', ["something"])
+    expect(output).toContain("Did something!")
+  })
+})


### PR DESCRIPTION
Rather than checking just the name, use the existing helper function `isDefaultCommand` to determine whether a command is a default command.

This supports using the `!` alias to register a default command.