### PR TITLE
feat: add checkUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,8 @@
     "hooks": {
       "pre-commit": "npm t && lint-staged"
     }
+  },
+  "dependencies": {
+    "pkg-up": "^4.0.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,7 @@ function createConfig({ dts, esm } = {}) {
       format: dts || esm ? 'esm' : 'cjs',
       file,
       exports: 'named',
+      inlineDynamicImports: true,
     },
     plugins: [
       nodeResolvePlugin({

--- a/src/CAC.ts
+++ b/src/CAC.ts
@@ -13,6 +13,7 @@ import {
   setByType,
   getFileName,
   camelcaseOptionName,
+  getCWDPackageJson,
 } from './utils'
 import { processArgs } from './node'
 import { getLatestVersion } from './npm'
@@ -348,13 +349,13 @@ class CAC extends EventEmitter {
    * @param pjson package.json object
    */
   async checkUpdate(
-    pjson: any,
     customTips: (p: {
       latestVersion: string
       curVersion: string
       pkgName: string
     }) => void
   ) {
+    const pjson = await getCWDPackageJson()
     const latestVersion = await getLatestVersion(pjson.name)
     try {
       // @ts-expect-error need developer to install semver

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,0 +1,23 @@
+import { exec } from 'child_process'
+
+export async function getLatestVersion(
+  pkgName: string
+): Promise<string | undefined> {
+  if (pkgName) {
+    return new Promise((resolve, reject) => {
+      try {
+        exec(
+          `npm show ${pkgName} version`,
+          {
+            encoding: 'utf-8',
+          },
+          (err, latestVersion) => {
+            if (err) return reject(err)
+            resolve(latestVersion)
+          }
+        )
+      } catch (error) {}
+    })
+  }
+  return undefined
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import Option from './Option'
+import { pkgUp } from 'pkg-up'
+import fs from 'fs'
 
 export const removeBrackets = (v: string) => v.replace(/[<[].+/, '').trim()
 
@@ -18,7 +20,7 @@ export const findAllBrackets = (v: string) => {
     return {
       required: match[0].startsWith('<'),
       value,
-      variadic
+      variadic,
     }
   }
 
@@ -62,7 +64,7 @@ export const getMriOptions = (options: Option[]) => {
         const hasStringTypeOption = options.some((o, i) => {
           return (
             i !== index &&
-            o.names.some(name => option.names.includes(name)) &&
+            o.names.some((name) => option.names.includes(name)) &&
             typeof o.required === 'boolean'
           )
         })
@@ -159,4 +161,9 @@ export class CACError extends Error {
       this.stack = new Error(message).stack
     }
   }
+}
+
+export const getCWDPackageJson = async () => {
+  const pjsonPath = (await pkgUp())!
+  return JSON.parse(fs.readFileSync(pjsonPath, { encoding: 'utf-8' }))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,7 +839,7 @@
   resolved "https://registry.npm.taobao.org/@types/mri/download/@types/mri-1.1.0.tgz#66555e4d797713789ea0fefdae0898d8170bf5af"
   integrity sha1-ZlVeTXl3E3ieoP79rgiY2BcL9a8=
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^18.15.11":
+"@types/node@*", "@types/node@>= 8":
   version "18.15.11"
   resolved "https://registry.anpm.alibaba-inc.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
   integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
@@ -2869,6 +2869,14 @@ find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+find-up@^6.2.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-6.3.0.tgz#2abab3d3280b2dc7ac10199ef324c4e002c8c790"
+  integrity sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==
+  dependencies:
+    locate-path "^7.1.0"
+    path-exists "^5.0.0"
 
 find-versions@^3.0.0:
   version "3.1.0"
@@ -4911,6 +4919,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-7.2.0.tgz#69cb1779bd90b35ab1e771e1f2f89a202c2a8a8a"
+  integrity sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==
+  dependencies:
+    p-locate "^6.0.0"
+
 lock-verify@^2.0.2, lock-verify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npm.taobao.org/lock-verify/download/lock-verify-2.1.0.tgz#fff4c918b8db9497af0c5fa7f6d71555de3ceb47"
@@ -6126,6 +6141,13 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npm.taobao.org/p-locate/download/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -6146,6 +6168,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-6.0.0.tgz#3da9a49d4934b901089dca3302fa65dc5a05c04f"
+  integrity sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==
+  dependencies:
+    p-limit "^4.0.0"
 
 p-map@^1.1.1:
   version "1.2.0"
@@ -6337,6 +6366,11 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-exists@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
+  integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npm.taobao.org/path-is-absolute/download/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -6432,6 +6466,13 @@ pkg-dir@^3.0.0:
   integrity sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=
   dependencies:
     find-up "^3.0.0"
+
+pkg-up@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-4.0.0.tgz#b2ca5e845979e31497d81520b621f4cdac2dcd75"
+  integrity sha512-N4zdA4sfOe6yCv+ulPCmpnIBQ5I60xfhDr1otdBBhKte9QtEf3bhfrfkW7dTb+IQ0iEx4ZDzas0kc1o5rdWpYg==
+  dependencies:
+    find-up "^6.2.0"
 
 please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
   version "3.1.1"
@@ -8839,6 +8880,11 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
 yup@^0.27.0:
   version "0.27.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,15 +839,10 @@
   resolved "https://registry.npm.taobao.org/@types/mri/download/@types/mri-1.1.0.tgz#66555e4d797713789ea0fefdae0898d8170bf5af"
   integrity sha1-ZlVeTXl3E3ieoP79rgiY2BcL9a8=
 
-"@types/node@*":
-  version "12.0.4"
-  resolved "https://registry.npm.taobao.org/@types/node/download/@types/node-12.0.4.tgz#46832183115c904410c275e34cf9403992999c32"
-  integrity sha1-RoMhgxFckEQQwnXjTPlAOZKZnDI=
-
-"@types/node@>= 8":
-  version "14.14.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.12.tgz#0b1d86f8c40141091285dea02e4940df73bba43f"
-  integrity sha512-ASH8OPHMNlkdjrEdmoILmzFfsJICvhBsFfAum4aKZ/9U4B6M6tTmTPh+f3ttWdD74CEGV5XvXWkbyfSdXaTd7g==
+"@types/node@*", "@types/node@>= 8", "@types/node@^18.15.11":
+  version "18.15.11"
+  resolved "https://registry.anpm.alibaba-inc.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
+  integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
export `checkUpdate` function  to print update message 

# Usage

```ts
import cac from 'cac'

const cli  = cac('foo')
cli.checkUpdate(); 

```

if current installed version is outdated, will print update message every time once `foo` command get run,
and the default message like:

![image](https://user-images.githubusercontent.com/49113249/231973728-1549c0fb-e09a-4b63-89e8-c2926380554c.png)

also the CLI developer can customize the message by the second callback param
```ts
cli.checkUpdate(
 ({
      latestVersion: string
      curVersion: string
      pkgName: string
    })=>{
//  print custom message
}
);
```


# Trade-Off 
- need developer to install `semver` themselves, but only if they call `checkUpdate` function. (it seems ok, since most of package dependent on semver, it can be accessed at most of time)


# TODO
- usage in `README`
-  pass test
