### PR TITLE
fix: variadic arguments error parsing

### DIFF
--- a/src/CAC.ts
+++ b/src/CAC.ts
@@ -328,6 +328,8 @@ class CAC extends EventEmitter {
 
     command.checkRequiredArgs()
 
+    command.checkPreviousArgument()
+
     const actionArgs: any[] = []
     command.args.forEach((arg, index) => {
       if (arg.variadic) {

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -253,6 +253,18 @@ class Command {
     }
   }
 
+  checkPreviousArgument() {
+    const length = this.args.length
+
+    for (let i = 0; i < length; i++) {
+      const { variadic, value } = this.args[i]
+
+      if (variadic && i !== length - 1) {
+        throw new CACError(`only the last argument can be variadic '${value}'`)
+      }
+    }
+  }
+
   /**
    * Check if the parsed options contain any unknown options
    *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,14 +3,14 @@ import Option from './Option'
 export const removeBrackets = (v: string) => v.replace(/[<[].+/, '').trim()
 
 export const findAllBrackets = (v: string) => {
-  const ANGLED_BRACKET_RE_GLOBAL = /<([^>]+)>/g
-  const SQUARE_BRACKET_RE_GLOBAL = /\[([^\]]+)\]/g
+  const BRACKET_RE_GLOBAL = /<([^>]+)>|\[([^\]]+)\]/g
 
   const res = []
 
   const parse = (match: string[]) => {
     let variadic = false
-    let value = match[1]
+    let value = match[1] ?? match[2]
+
     if (value.startsWith('...')) {
       value = value.slice(3)
       variadic = true
@@ -22,14 +22,9 @@ export const findAllBrackets = (v: string) => {
     }
   }
 
-  let angledMatch
-  while ((angledMatch = ANGLED_BRACKET_RE_GLOBAL.exec(v))) {
-    res.push(parse(angledMatch))
-  }
-
-  let squareMatch
-  while ((squareMatch = SQUARE_BRACKET_RE_GLOBAL.exec(v))) {
-    res.push(parse(squareMatch))
+  let match
+  while ((match = BRACKET_RE_GLOBAL.exec(v))) {
+    res.push(parse(match))
   }
 
   return res


### PR DESCRIPTION
Although it is stated in the readme that variadic arguments can only the last parameter, there is no syntax check in the code.

## Code

```javascript
const cli = require('cac')()

cli
  .command('parse [a] [...b] [...c] [d]', 'Command parse')
  .action((a, b, c, d, options) => {
    console.log(a)
    console.log(b)
    console.log(c)
    console.log(d)
  })

cli.parse()
```

## Terminal

This code still works, but it doesn't work as expected

### Current

```shell
$ node index.js parse a b c d

a
['b', 'c', 'd']
['c', 'd']
d
```

### Improved

```shell
$ node index.js parse a b c d

CommandError: only the last argument can be variadic 'b'
```

(｡･∀･)ﾉﾞ Will now directly throw an exception.
