### PR TITLE
feat: Option type default to string

### DIFF
--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -54,7 +54,7 @@ test('negated option', () => {
 
   cli.option('--foo [foo]', 'Set foo').option('--no-foo', 'Disable foo')
 
-  cli.option('--bar [bar]', 'Set bar').option('--no-bar', 'Disable bar')
+  cli.option('--bar', 'Set bar').option('--no-bar', 'Disable bar')
 
   const { options } = cli.parse(['node', 'bin', '--foo', 'foo', '--bar'])
   expect(options).toEqual({
@@ -115,7 +115,7 @@ test('array types without transformFunction', () => {
         type: [],
       }
     )
-    .option('--scale [level]', 'Scaling level')
+    .option('--scale', 'Scaling level')
 
   const { options: options1 } = cli.parse(
     `node bin --externals.env.prod production --scale`.split(' ')
@@ -142,7 +142,7 @@ test('array types with transformFunction', () => {
     .option('--config <configFlie>', 'Use config file for building', {
       type: [String],
     })
-    .option('--scale [level]', 'Scaling level')
+    .option('--scale', 'Scaling level')
 
   const { options } = cli.parse(
     `node bin build app.js --config config.js --scale`.split(' ')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export const findAllBrackets = (v: string) => {
     return {
       required: match[0].startsWith('<'),
       value,
-      variadic
+      variadic,
     }
   }
 
@@ -40,10 +40,11 @@ interface MriOptions {
     [k: string]: string[]
   }
   boolean: string[]
+  string: string[]
 }
 
 export const getMriOptions = (options: Option[]) => {
-  const result: MriOptions = { alias: {}, boolean: [] }
+  const result: MriOptions = { alias: {}, boolean: [], string: [] }
 
   for (const [index, option] of options.entries()) {
     // We do not set default values in mri options
@@ -62,7 +63,7 @@ export const getMriOptions = (options: Option[]) => {
         const hasStringTypeOption = options.some((o, i) => {
           return (
             i !== index &&
-            o.names.some(name => option.names.includes(name)) &&
+            o.names.some((name) => option.names.includes(name)) &&
             typeof o.required === 'boolean'
           )
         })
@@ -72,6 +73,8 @@ export const getMriOptions = (options: Option[]) => {
       } else {
         result.boolean.push(option.names[0])
       }
+    } else {
+      result.string.push(option.names[0])
     }
   }
 


### PR DESCRIPTION
related issue: https://github.com/cacjs/cac/issues/162

**BREAK CHANGE!**

Options will convert to string by default

example:

cli -v 3.2 -p 12345678910

options: {v: "3.2", p: "12345678910"}