### PR TITLE
fix(option): register kebab-case names with the parser

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -13,6 +13,15 @@ export class Option {
   name: string
   /** Option name and aliases */
   names: string[]
+  /**
+   * Original (pre-camelcase) option names, e.g. `include-locked` for
+   * `--include-locked`. Needed so the underlying parser can recognise
+   * the kebab-case form on the command line as a boolean flag — without
+   * this, mri would consume the next positional argument as the option's
+   * value (e.g. `--include-locked latest` was parsed as
+   * `{ includeLocked: 'latest' }` with `latest` removed from the args).
+   */
+  rawNames: string[]
   isBoolean?: boolean
   // `required` will be a boolean for options with brackets
   required?: boolean
@@ -28,7 +37,7 @@ export class Option {
     rawName = rawName.replaceAll('.*', '')
 
     this.negated = false
-    this.names = removeBrackets(rawName)
+    const stripped = removeBrackets(rawName)
       .split(',')
       .map((v: string) => {
         let name = v.trim().replace(/^-{1,2}/, '')
@@ -37,8 +46,15 @@ export class Option {
           name = name.replace(/^no-/, '')
         }
 
-        return camelcaseOptionName(name)
+        return name
       })
+    this.rawNames = stripped
+      .slice()
+      .sort((a, b) =>
+        camelcaseOptionName(a).length > camelcaseOptionName(b).length ? 1 : -1,
+      )
+    this.names = stripped
+      .map((name) => camelcaseOptionName(name))
       .sort((a, b) => (a.length > b.length ? 1 : -1)) // Sort names
 
     // Use the longest name (last one) as actual option name

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,8 +56,13 @@ export function getMriOptions(options: Option[]): MriOptions {
     // Since its type (typeof) will be used to cast parsed arguments.
     // Which mean `--foo foo` will be parsed as `{foo: true}` if we have `{default:{foo: true}}`
     // Set alias
-    if (option.names.length > 1) {
-      result.alias[option.names[0]] = option.names.slice(1)
+    // Build the alias list using both the camelCased names (for end-user
+    // ergonomics — e.g. `--includeLocked` works) and the original
+    // kebab-case forms (so the parser actually recognises the form the
+    // user typed on the command line).
+    const aliasNames = mergeAliasNames(option.names, option.rawNames)
+    if (aliasNames.length > 1) {
+      result.alias[aliasNames[0]] = aliasNames.slice(1)
     }
     // Set boolean
     if (option.isBoolean) {
@@ -72,15 +77,33 @@ export function getMriOptions(options: Option[]): MriOptions {
           )
         })
         if (!hasStringTypeOption) {
-          result.boolean.push(option.names[0])
+          result.boolean.push(aliasNames[0])
         }
       } else {
-        result.boolean.push(option.names[0])
+        result.boolean.push(aliasNames[0])
       }
     }
   }
 
   return result
+}
+
+// Merge camelCased names with the original kebab-case names, preserving
+// uniqueness and the original "shortest first" ordering. The shortest
+// alias is kept as the canonical entry — typically the short flag like
+// `-l` — and remaining names follow as aliases for mri.
+function mergeAliasNames(names: string[], rawNames: string[]): string[] {
+  const merged: string[] = []
+  const seen = new Set<string>()
+  const push = (name: string) => {
+    if (!seen.has(name)) {
+      seen.add(name)
+      merged.push(name)
+    }
+  }
+  for (const name of names) push(name)
+  for (const raw of rawNames) push(raw)
+  return merged
 }
 
 export function findLongest(arr: string[]): string {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -64,6 +64,37 @@ test('negated option', () => {
   })
 })
 
+test('kebab-case boolean option does not consume next positional arg (#119)', () => {
+  const cli = cac()
+  cli.command('[mode]').option('--include-locked, -l', 'include locked')
+
+  // Long kebab-case form
+  const a = cli.parse(['node', 'bin', '--include-locked', 'latest'], {
+    run: false,
+  })
+  expect(a.options.includeLocked).toBe(true)
+  expect(a.options.l).toBe(true)
+  expect(a.args).toEqual(['latest'])
+
+  // Short alias
+  const b = cli.parse(['node', 'bin', '-l', 'latest'], { run: false })
+  expect(b.options.includeLocked).toBe(true)
+  expect(b.options.l).toBe(true)
+  expect(b.args).toEqual(['latest'])
+})
+
+test('long hyphenated option propagates to camelCase aliases (#119)', () => {
+  const cli = cac()
+  cli.option('-c, --clear, --clear-screen', 'desc')
+
+  for (const flag of ['-c', '--clear', '--clearScreen', '--clear-screen']) {
+    const { options } = cli.parse(['node', 'bin', flag], { run: false })
+    expect(options.c).toBe(true)
+    expect(options.clear).toBe(true)
+    expect(options.clearScreen).toBe(true)
+  }
+})
+
 test('double dashes', () => {
   const cli = cac()
 


### PR DESCRIPTION
## Summary

Option names were only stored in their camelCased form, so the underlying mri parser never learned that the original kebab form (e.g. `include-locked`) was a boolean flag, nor that it aliased the camelCase one.

This produced two user-visible bugs:

### 1. Kebab-case boolean options swallowed the next positional arg

```js
cli.command('[mode]').option('--include-locked, -l', 'desc')

cli.parse(['node', 'bin', '--include-locked', 'latest'])
// Before: { options: { includeLocked: 'latest' }, args: [] }     ❌
// After:  { options: { includeLocked: true,  l: true }, args: ['latest'] } ✅

cli.parse(['node', 'bin', '-l', 'latest'])
// Already worked before; still works.
```

### 2. Long hyphenated aliases didn't propagate (#119)

```js
cli.option('-c, --clear, --clear-screen')

cli.parse(['node', 'bin', '--clear-screen'])
// Before: { clearScreen: true }                          ❌
// After:  { c: true, clear: true, clearScreen: true }    ✅
```

## Fix

`Option` now tracks the original (pre-camelcase) names on `rawNames`, and `getMriOptions` registers both the camelCased and kebab-case forms in mri's `alias` and `boolean` arrays. The canonical name (used as the alias key) is still the shortest entry, preserving existing alias-key behavior.

## Test plan

- [x] `pnpm vitest run` — 19 tests pass (2 new):
  - kebab-case boolean does not consume next positional
  - long hyphenated alias propagates to short and camelCase aliases
- [x] `pnpm lint`
- [x] `pnpm exec tsdown` — clean build, manual smoke-tested all four invocation forms

## Downstream impact

This also fixes [antfu/taze#187](https://github.com/antfu/taze/issues/187) (`--include-locked` and `-l` work differently) and similar bugs in any cac-based CLI that uses kebab-case boolean options.

Fixes #119