### PR TITLE
docs: add skill for llm guidance [ci skip]

### DIFF
--- a/skills/GENERATION.md
+++ b/skills/GENERATION.md
@@ -1,0 +1,125 @@
+# Skills Generation Information
+
+This document records how the CAC skill was generated and how to keep it synchronized with the repository examples.
+
+## Generation Details
+
+**Generated from repository content at:**
+
+- **Commit SHA**: `be7d57e5f5da54dd201784cc31d1c7cce019a3fe`
+- **Date**: 2026-04-07
+- **Commit**: chore: upgrade deps
+
+**Source material:**
+
+- Public docs: `/README.md`
+- Canonical examples: `/examples`
+- Implementation details checked against `/src`
+
+**Generation date**: 2026-05-17
+
+## Structure
+
+```text
+skills/
+├── GENERATION.md
+└── cac/
+    ├── SKILL.md
+    └── references/
+        ├── basic-usage.md
+        ├── browser.md
+        ├── command-examples.md
+        ├── command-options.md
+        ├── default-command-inverted.md
+        ├── default-command.md
+        ├── deno.md
+        ├── dot-nested-options.md
+        ├── help.md
+        ├── ignore-default-value.md
+        ├── negated-option.md
+        ├── sub-command.md
+        └── variadic-arguments.md
+```
+
+## Source-to-Reference Mapping
+
+Reference files mirror the canonical examples so changes have an obvious destination:
+
+| Example source | Skill reference |
+| --- | --- |
+| `examples/basic-usage.ts` | `skills/cac/references/basic-usage.md` |
+| `examples/browser/` | `skills/cac/references/browser.md` |
+| `examples/command-examples.ts` | `skills/cac/references/command-examples.md` |
+| `examples/command-options.ts` | `skills/cac/references/command-options.md` |
+| `examples/default-command-inverted.ts` | `skills/cac/references/default-command-inverted.md` |
+| `examples/default-command.ts` | `skills/cac/references/default-command.md` |
+| `examples/deno.ts` | `skills/cac/references/deno.md` |
+| `examples/dot-nested-options.ts` | `skills/cac/references/dot-nested-options.md` |
+| `examples/help.ts` | `skills/cac/references/help.md` |
+| `examples/ignore-default-value.ts` | `skills/cac/references/ignore-default-value.md` |
+| `examples/negated-option.ts` | `skills/cac/references/negated-option.md` |
+| `examples/sub-command.ts` | `skills/cac/references/sub-command.md` |
+| `examples/variadic-arguments.ts` | `skills/cac/references/variadic-arguments.md` |
+
+## How to Update Skills
+
+When examples or public behavior change:
+
+### 1. Check changes since generation
+
+```bash
+git diff be7d57e5..HEAD -- examples/ README.md src/
+git diff --name-only be7d57e5..HEAD -- examples/ README.md src/
+git log --oneline be7d57e5..HEAD -- examples/ README.md src/
+```
+
+### 2. Update process
+
+**When an existing example changes**
+
+- Update the same-named reference file.
+- Update `SKILL.md` if the change alters the scenario index, syntax table, or a core behavior rule.
+
+**When a new example is added**
+
+- Add a same-named reference file under `skills/cac/references/`.
+- Add it to the `Scenario References` table in `SKILL.md`.
+- Add it to the source-to-reference mapping in this file.
+
+**When an example is removed or renamed**
+
+- Remove or rename the matching reference file.
+- Update the `Scenario References` table in `SKILL.md`.
+- Update the mapping in this file.
+
+**When public behavior changes without an example change**
+
+- Re-check `README.md` and `/src`.
+- Update `SKILL.md` first, then add or revise references only when a scenario example is affected.
+
+### 3. Update checklist
+
+- [ ] Read the diff for `examples/`, `README.md`, and `src/`
+- [ ] Update same-named reference files for changed examples
+- [ ] Add/remove references for added/removed examples
+- [ ] Update the `Scenario References` table in `SKILL.md`
+- [ ] Update this `GENERATION.md` with the new SHA, date, and mapping
+- [ ] Re-run skill validation
+
+## Style Guidelines
+
+- Preserve CAC's own example taxonomy instead of inventing a second one.
+- Keep `SKILL.md` focused on rules, selection, and invariants.
+- Keep references scenario-specific: one example, its intended use, and only the notes needed to apply it correctly.
+- Prefer source-aligned examples over synthetic variants unless a source example is misleading or outdated.
+
+## Version History
+
+| Date | SHA | Changes |
+| --- | --- | --- |
+| 2026-05-17 | `be7d57e5` | Initial CAC skill with one-to-one example references |
+
+---
+
+Last updated: 2026-05-17  
+Current SHA: `be7d57e5`

--- a/skills/GENERATION.md
+++ b/skills/GENERATION.md
@@ -24,6 +24,7 @@ This document records how the CAC skill was generated and how to keep it synchro
 skills/
 ├── GENERATION.md
 └── cac/
+    ├── README.md
     ├── SKILL.md
     └── references/
         ├── basic-usage.md

--- a/skills/cac/README.md
+++ b/skills/cac/README.md
@@ -1,0 +1,57 @@
+# CAC Skill
+
+An agent skill that helps AI coding agents understand and use [CAC](https://github.com/cacjs/cac), the lightweight CLI framework.
+
+## Installation
+
+```bash
+npx skills add cacjs/cac --skill cac
+```
+
+## What's Included
+
+The CAC skill provides knowledge about:
+
+- **Command Modeling** - Global parsing, subcommands, and default commands
+- **Argument Syntax** - Required, optional, and variadic positional args
+- **Option Parsing** - Boolean flags, automatic negation, repeated options, arrays, and dot-nested options
+- **CLI UX** - Help, version output, usage text, and command examples
+- **Execution Flow** - Automatic execution, manual command running, and centralized error handling
+- **Scenario References** - Source-aligned examples for common CAC patterns
+
+## Usage
+
+Once installed, agents can use the CAC skill when:
+
+- Building or reviewing CAC-based CLIs
+- Defining commands, options, and arguments
+- Working with boolean flags or repeated options
+- Handling default commands, nested options, or variadic args
+- Explaining CAC parsing behavior
+
+### Example Prompts
+
+```text
+Build a CAC CLI with a build command and repeated --include options
+```
+
+```text
+Explain how --open and --no-open work in CAC
+```
+
+```text
+Add a default command with variadic file arguments using CAC
+```
+
+```text
+Help me handle CAC command errors in one place
+```
+
+## Documentation
+
+- [CAC README](https://github.com/cacjs/cac#readme)
+- [GitHub Repository](https://github.com/cacjs/cac)
+
+## License
+
+MIT

--- a/skills/cac/SKILL.md
+++ b/skills/cac/SKILL.md
@@ -54,7 +54,7 @@ Install with `pnpm add cac`.
 | Required option value | `--out <dir>` | missing value throws |
 | Global option | `cli.option('--cwd <dir>', ...)` | available to all commands |
 | Command option | `command.option('--watch', ...)` | scoped to one command |
-| Repeated option | `--include a --include b` | becomes an array |
+| Repeated option | `--include a --include b` | becomes `['a', 'b']` |
 | Dot-nested option | `--env.API_SECRET xxx` | becomes `options.env.API_SECRET` |
 | Passthrough args | `-- pnpm test` | stored in `options['--']` |
 
@@ -82,6 +82,20 @@ cli
   .option('--no-config', 'Disable config file')
   .option('--config <path>', 'Use a custom config file')
 ```
+
+For array-valued options, prefer repeated flags:
+
+```bash
+--include a --include b --include c
+```
+
+CAC parses that as:
+
+```ts
+{ include: ['a', 'b', 'c'] }
+```
+
+Do not model array input as `--include a,b,c` and split the string manually unless the CLI intentionally documents comma-separated syntax. If consumers should always receive an array, use `type: []` so even one `--include a` becomes `['a']`.
 
 ## Scenario References
 

--- a/skills/cac/SKILL.md
+++ b/skills/cac/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: cac
+description: Build and maintain command-line interfaces with CAC. Use when a task involves the `cac` package, authoring or reviewing CLI apps, defining commands/options/arguments, generating help or version output, handling parse errors, or explaining CAC-specific behavior such as default commands, boolean negation, variadic args, dot-nested options, and `--` passthrough.
+---
+
+# CAC
+
+Use CAC to build small, expressive CLIs with a compact command grammar:
+
+```ts
+import { cac } from 'cac'
+
+const cli = cac('my-cli')
+
+cli
+  .command('build <entry> [...files]', 'Build project files')
+  .option('--minify', 'Minify output')
+  .action((entry, files, options) => {
+    console.info({ entry, files, options })
+  })
+
+cli.help()
+cli.version('1.0.0')
+cli.parse()
+```
+
+Install with `pnpm add cac`.
+
+## Build CLIs This Way
+
+1. Choose the command shape first.
+   - Use global parsing only for tiny CLIs.
+   - Use `cli.command(...)` for verb-based CLIs.
+   - Use a default command when the main behavior should run without an explicit verb.
+2. Model positional arguments before options.
+   - `<arg>` is required.
+   - `[arg]` is optional.
+   - `...` is variadic and may only appear on the final positional argument.
+3. Attach options at the narrowest useful scope.
+   - Use `cli.option(...)` for flags shared by multiple commands.
+   - Use `command.option(...)` for command-specific flags.
+4. Add `help()` and `version()` for user-facing tools.
+5. Use plain `cli.parse()` for simple flows; use `cli.parse(argv, { run: false })` plus `await cli.runMatchedCommand()` when you need centralized or async error handling.
+
+## Syntax and Parsing
+
+| Need | CAC form | Result |
+| --- | --- | --- |
+| Required arg | `build <entry>` | action receives `entry` |
+| Optional arg | `build [entry]` | action receives `undefined` when omitted |
+| Variadic arg | `build <entry> [...rest]` | final action arg is an array |
+| Boolean flag | `--open` | accepts both `--open` and `--no-open` automatically |
+| Optional option value | `--scale [level]` | value or `true` |
+| Required option value | `--out <dir>` | missing value throws |
+| Global option | `cli.option('--cwd <dir>', ...)` | available to all commands |
+| Command option | `command.option('--watch', ...)` | scoped to one command |
+| Repeated option | `--include a --include b` | becomes an array |
+| Dot-nested option | `--env.API_SECRET xxx` | becomes `options.env.API_SECRET` |
+| Passthrough args | `-- pnpm test` | stored in `options['--']` |
+
+Kebab-case option names are read in camelCase:
+
+```ts
+cli.option('--clear-screen', 'Clear screen')
+// read options.clearScreen
+```
+
+Only the first segment is camel-cased, so `--env.API_SECRET` becomes `options.env.API_SECRET`.
+
+Bare booleans already accept negation:
+
+```ts
+cli.option('--open', 'Open browser')
+// --open    -> { open: true }
+// --no-open -> { open: false }
+```
+
+Declare an explicit negated option only when the negated form should appear in help, should default to `true`, or must pair with a required-value option:
+
+```ts
+cli
+  .option('--no-config', 'Disable config file')
+  .option('--config <path>', 'Use a custom config file')
+```
+
+## Scenario References
+
+Use the reference that matches the user's task:
+
+| Scenario | Reference |
+| --- | --- |
+| Parse args plus global options | [basic-usage](references/basic-usage.md) |
+| Parse explicit argv outside normal Node flow | [browser](references/browser.md) |
+| Add examples to command help | [command-examples](references/command-examples.md) |
+| Add command-scoped options | [command-options](references/command-options.md) |
+| Define an empty-name default command | [default-command](references/default-command.md) |
+| Make a named command also act as default | [default-command-inverted](references/default-command-inverted.md) |
+| Use CAC from Deno | [deno](references/deno.md) |
+| Parse nested option keys | [dot-nested-options](references/dot-nested-options.md) |
+| Combine help, version, global options, and a default command | [help](references/help.md) |
+| Show defaults in help without filling parsed output | [ignore-default-value](references/ignore-default-value.md) |
+| Declare an explicit negated option | [negated-option](references/negated-option.md) |
+| Combine multiple subcommands in one CLI | [sub-command](references/sub-command.md) |
+| Accept trailing positional lists | [variadic-arguments](references/variadic-arguments.md) |
+
+## Centralized Error Handling
+
+```ts
+try {
+  cli.parse(process.argv, { run: false })
+  await cli.runMatchedCommand()
+} catch (error) {
+  console.error(error)
+  process.exit(1)
+}
+```
+
+## Important Behaviors
+
+- When a matched command has an action, CAC validates unknown options, missing option values, missing required args, and unused extra args.
+- Use `allowUnknownOptions()` only when forwarding another tool's flags.
+- Use `ignoreOptionDefaultValue()` when help should show defaults but parsed output should stay sparse.
+- Variadic positional args arrive as arrays.
+- `options['--']` is reserved for everything after a double dash.
+- `command.alias(name)` accepts plain aliases; use `alias('!')` to mark a named command as the default command.
+- Listen to `command:<name>`, `command:!`, and `command:*` when you need matched/default/unknown-command hooks.
+
+## API Surface
+
+### CLI
+
+```ts
+cac(name?)
+cli.command(name, description?, config?)
+cli.option(name, description, config?)
+cli.help(callback?)
+cli.version(version, customFlags?)
+cli.usage(text)
+cli.example(example)
+cli.parse(argv?, { run }?)
+cli.runMatchedCommand()
+cli.outputHelp()
+cli.outputVersion()
+```
+
+`cli.parse()` returns `{ args, options }` and also sets:
+
+```ts
+cli.rawArgs
+cli.args
+cli.options
+cli.matchedCommand
+cli.matchedCommandName
+```
+
+### Command
+
+```ts
+command.option(name, description, config?)
+command.action(callback)
+command.alias(name)
+command.allowUnknownOptions()
+command.ignoreOptionDefaultValue()
+command.example(example)
+command.usage(text)
+```
+
+Option config supports:
+
+```ts
+{
+  default?: any
+  type?: any[]
+}
+```
+
+Use `type: []` to force array output and `type: [String]` to transform each value.

--- a/skills/cac/references/basic-usage.md
+++ b/skills/cac/references/basic-usage.md
@@ -1,0 +1,16 @@
+# Basic Usage
+
+Use this pattern when the CLI only needs to parse free-form positional args plus global options.
+
+```ts
+import { cac } from 'cac'
+const cli = cac()
+
+cli.option('--type [type]', 'Choose a project type')
+
+const parsed = cli.parse()
+console.info(JSON.stringify(parsed, null, 2))
+```
+
+- Use `cli.option(...)` for global options.
+- `cli.parse()` returns `{ args, options }` even when no command is defined.

--- a/skills/cac/references/browser.md
+++ b/skills/cac/references/browser.md
@@ -1,0 +1,14 @@
+# Browser
+
+Use this pattern when running CAC outside Node's normal `process.argv` flow, such as in a browser demo or test harness.
+
+```ts
+import cac from 'cac'
+
+const cli = cac('browser-cli').help().version('0.0.0')
+const parsed = cli.parse(['node', 'cli', '--help'])
+console.info(parsed)
+```
+
+- Pass an explicit argv array when runtime process args are unavailable.
+- Browser usage still supports regular help/version behavior.

--- a/skills/cac/references/command-examples.md
+++ b/skills/cac/references/command-examples.md
@@ -1,0 +1,20 @@
+# Command Examples
+
+Use command examples when help output should show concrete invocations.
+
+```ts
+import { cac } from 'cac'
+const cli = cac()
+
+cli
+  .command('build', 'Build project')
+  .example('cli build foo.js')
+  .example((name) => `${name} build foo.js`)
+  .option('--type [type]', 'Choose a project type')
+
+const parsed = cli.parse()
+console.info(JSON.stringify(parsed, null, 2))
+```
+
+- `.example(...)` accepts either a string or a function receiving the CLI name.
+- Command examples appear in that command's help output.

--- a/skills/cac/references/command-options.md
+++ b/skills/cac/references/command-options.md
@@ -1,0 +1,21 @@
+# Command Options
+
+Use command-scoped options when a flag only belongs to one command.
+
+```ts
+import { cac } from 'cac'
+const cli = cac()
+
+cli
+  .command('rm <dir>', 'Remove a dir')
+  .option('-r, --recursive', 'Remove recursively')
+  .action((dir, options) => {
+    console.info(`remove ${dir}${options.recursive ? ' recursively' : ''}`)
+  })
+
+cli.help()
+cli.parse()
+```
+
+- Positional args are passed before the final `options` argument.
+- Command options are validated only when that command is used.

--- a/skills/cac/references/default-command-inverted.md
+++ b/skills/cac/references/default-command-inverted.md
@@ -1,0 +1,20 @@
+# Default Command Inverted
+
+Use this form when the command should have a normal visible name but also act as the default command.
+
+```ts
+import { cac } from 'cac'
+const cli = cac()
+
+cli
+  .command('something', 'Do something')
+  .alias('!')
+  .action(() => {
+    console.info('Did something!')
+  })
+
+cli.parse()
+```
+
+- `alias('!')` marks a named command as the default command.
+- This keeps `something` callable while also handling empty invocation.

--- a/skills/cac/references/default-command.md
+++ b/skills/cac/references/default-command.md
@@ -1,0 +1,20 @@
+# Default Command
+
+Use this form when the CLI's primary behavior should run with no explicit command name.
+
+```ts
+import { cac } from 'cac'
+const cli = cac()
+
+cli
+  .command('', 'Do something')
+  .alias('something')
+  .action(() => {
+    console.info('Did something!')
+  })
+
+cli.parse()
+```
+
+- An empty command name makes the command default.
+- Add a normal alias when the same behavior should also be invokable by name.

--- a/skills/cac/references/deno.md
+++ b/skills/cac/references/deno.md
@@ -1,0 +1,14 @@
+# Deno
+
+Use the JSR import path when building a CAC CLI for Deno.
+
+```ts
+import { cac } from 'jsr:@cac/cac@7.0.0-beta.1'
+
+const cli = cac('my-program')
+const parsed = cli.parse()
+console.info(JSON.stringify(parsed, null, 2))
+```
+
+- The command model is the same as in Node.
+- Keep the versioned JSR specifier aligned with the package version you intend to target.

--- a/skills/cac/references/dot-nested-options.md
+++ b/skills/cac/references/dot-nested-options.md
@@ -1,0 +1,23 @@
+# Dot-Nested Options
+
+Use dot-nested options when users need to provide structured values from the CLI.
+
+```ts
+import { cac } from 'cac'
+const cli = cac()
+
+cli
+  .command('build', 'desc')
+  .option('--env <env>', 'Set envs')
+  .option('--foo-bar <value>', 'Set foo bar')
+  .example('--env.API_SECRET xxx')
+  .action((options) => {
+    console.info(options)
+  })
+
+cli.help()
+cli.parse()
+```
+
+- `--env.API_SECRET xxx` becomes `options.env.API_SECRET`.
+- Only the first segment is camel-cased, so `--foo-bar` becomes `fooBar` while nested keys stay unchanged.

--- a/skills/cac/references/help.md
+++ b/skills/cac/references/help.md
@@ -1,0 +1,30 @@
+# Help and Version
+
+Use this pattern for a user-facing CLI with global options, commands, default commands, help, and version output.
+
+```ts
+import { cac } from 'cac'
+
+const cli = cac()
+
+cli.option('--type [type]', 'Choose a project type', {
+  default: 'node',
+})
+cli.option('--name <name>', 'Provide your name')
+
+cli.command('lint [...files]', 'Lint files').action((files, options) => {
+  console.info(files, options)
+})
+
+cli.command('[...files]', 'Run files').action((files, options) => {
+  console.info('run', files, options)
+})
+
+cli.help()
+cli.version('0.0.0')
+cli.parse()
+```
+
+- `help()` registers `-h, --help`.
+- `version()` registers `-v, --version` by default.
+- Default commands still appear in global help.

--- a/skills/cac/references/ignore-default-value.md
+++ b/skills/cac/references/ignore-default-value.md
@@ -1,0 +1,21 @@
+# Ignore Default Value
+
+Use `ignoreOptionDefaultValue` when help should show defaults but parsed output should not be prefilled.
+
+```ts
+import { cac } from 'cac'
+const cli = cac()
+
+cli
+  .command('build', 'Build project', {
+    ignoreOptionDefaultValue: true,
+  })
+  .option('--type [type]', 'Choose a project type', {
+    default: 'node',
+  })
+
+const parsed = cli.parse()
+console.info(JSON.stringify(parsed, null, 2))
+```
+
+- This is useful when downstream logic needs to distinguish omitted values from defaults.

--- a/skills/cac/references/negated-option.md
+++ b/skills/cac/references/negated-option.md
@@ -1,0 +1,16 @@
+# Negated Option
+
+Use an explicitly negated option when the negative form itself should be declared and documented.
+
+```ts
+import { cac } from 'cac'
+const cli = cac()
+
+cli.option('--no-clear-screen', 'Do not clear screen')
+
+const parsed = cli.parse()
+console.info(JSON.stringify(parsed, null, 2))
+```
+
+- Explicit `--no-clear-screen` gives `clearScreen` a default value of `true` when no explicit default is provided.
+- A bare boolean like `--open` already accepts `--no-open` automatically; declare the negated form only when its help/default semantics matter.

--- a/skills/cac/references/sub-command.md
+++ b/skills/cac/references/sub-command.md
@@ -1,0 +1,41 @@
+# Sub Commands
+
+Use this example as the broadest reference for combining multiple CAC features in one CLI.
+
+```ts
+import { cac } from 'cac'
+const cli = cac()
+
+cli
+  .command('deploy [path]', 'Deploy to AWS')
+  .option('--token <token>', 'Your access token')
+  .example('deploy ./dist')
+
+cli
+  .command('bar <a> <b> [...rest]', 'The bar command')
+  .option('--bad', 'It is bad')
+  .action((a, b, rest) => {
+    console.info(a, b, rest)
+  })
+
+cli
+  .command('cook <...food>', 'Cook some good')
+  .option('--bar', 'Bar is a boolean option')
+  .action((food, options) => {
+    console.info(food, options)
+  })
+
+cli
+  .command('[...files]', 'Build given files')
+  .option('--no-minify', 'Do not minify the output')
+  .option('--source-map', 'Enable source maps')
+  .action((args, flags) => {
+    console.info(args, flags)
+  })
+
+cli.version('0.0.0')
+cli.help()
+cli.parse()
+```
+
+- This covers optional args, required args, variadic args, command examples, explicit negation, a default command, help, and version output.

--- a/skills/cac/references/variadic-arguments.md
+++ b/skills/cac/references/variadic-arguments.md
@@ -1,0 +1,23 @@
+# Variadic Arguments
+
+Use a variadic positional argument when a command should accept a trailing list of values.
+
+```ts
+import { cac } from 'cac'
+const cli = cac()
+
+cli
+  .command('build <entry> [...otherFiles]', 'Build your app')
+  .option('--foo', 'Foo option')
+  .action((entry, otherFiles, options) => {
+    console.info(entry)
+    console.info(otherFiles)
+    console.info(options)
+  })
+
+cli.help()
+cli.parse()
+```
+
+- Only the final positional argument may be variadic.
+- Variadic args arrive as an array in the action callback.


### PR DESCRIPTION
LLMs often do not use CAC correctly, especially around boolean flags, array handling.

This adds a skill generated from the codebase and examples folder to help LLMs use CAC more accurately.